### PR TITLE
Fixes permission and extension issue on Linux

### DIFF
--- a/installTerragrunt/index.ts
+++ b/installTerragrunt/index.ts
@@ -1,6 +1,8 @@
 import taskLib = require('azure-pipelines-task-lib/task');
 import toolLib = require('azure-pipelines-tool-lib/tool');
 import os = require('os');
+import * as fs from 'fs';
+import * as path from 'path';
 
 async function run() {
     try {
@@ -15,9 +17,13 @@ async function run() {
 
         const downloaded: string = await toolLib.downloadTool(downloadUrl);
 
-        const cached: string = await toolLib.cacheFile(downloaded,`terragrunt.exe`,`terragrunt`, versionNumber);
+        const filename =  os.platform() == 'win32' ? 'terragrunt.exe' : 'terragrunt'
+        const cached: string = await toolLib.cacheFile(downloaded, filename, `terragrunt`, versionNumber);
 
         toolLib.prependPath(cached);
+
+        console.log('Elevating terragrunt privileges');
+        fs.chmodSync(path.join(cached, filename), "777");
 
         taskLib.setResult(taskLib.TaskResult.Succeeded, 'Terragrunt has been installed.');
     }

--- a/installTerragrunt/package.json
+++ b/installTerragrunt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-terragrunt",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "description": "Installs terragrunt",
   "main": "index.js",
   "scripts": {

--- a/installTerragrunt/package.json
+++ b/installTerragrunt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-terragrunt",
-  "version": "0.19.0",
+  "version": "0.28.16",
   "description": "Installs terragrunt",
   "main": "index.js",
   "scripts": {

--- a/installTerragrunt/task.json
+++ b/installTerragrunt/task.json
@@ -2,7 +2,7 @@
     "id": "c67b072a-0853-4578-95c1-acbc26e8897a",
     "name": "installTerragrunt",
     "friendlyName": "Install Terragrunt",
-    "description": "Installs terragrunt on all platforms",
+    "description": "Installs terragrunt for Windows, Linux, and Mac",
     "helpMarkDown": "https://github.com/gruntwork-io/terragrunt",
     "category": "Tool",
     "author": "Big Avocado",

--- a/installTerragrunt/task.json
+++ b/installTerragrunt/task.json
@@ -2,7 +2,7 @@
     "id": "c67b072a-0853-4578-95c1-acbc26e8897a",
     "name": "installTerragrunt",
     "friendlyName": "Install Terragrunt",
-    "description": "Installs terragrunt for Windows, Linux, and Mac",
+    "description": "Installs terragrunt for Windows, Linux, and MacOS",
     "helpMarkDown": "https://github.com/gruntwork-io/terragrunt",
     "category": "Tool",
     "author": "Big Avocado",

--- a/installTerragrunt/task.json
+++ b/installTerragrunt/task.json
@@ -2,7 +2,7 @@
     "id": "c67b072a-0853-4578-95c1-acbc26e8897a",
     "name": "installTerragrunt",
     "friendlyName": "Install Terragrunt",
-    "description": "Installs terragrunt, currently only for windows",
+    "description": "Installs terragrunt on all platforms",
     "helpMarkDown": "https://github.com/gruntwork-io/terragrunt",
     "category": "Tool",
     "author": "Big Avocado",
@@ -16,7 +16,7 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 1,
+        "Minor": 2,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "Terragrunt",
     "publisher": "BigAvocado",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "name": "Install Terragrunt",
     "description": "Installs terragrunt",
     "public": false,


### PR DESCRIPTION
A couple of things this PR fixes:

- Removes extension on cached terragrunt executable for Linux
- Adds execute permissions to executable (the main reason this doesn't work currently)
- Updated description and version numbers to push Azure DevOps along (because we all know how fun it is to work with :| )

ps. Running this in my pipelines privately for Linux and re-tested it for Windows 